### PR TITLE
chore: add AGENTS.md symlink to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## What

Adds `AGENTS.md` as a relative symlink to `CLAUDE.md`.

## Why

`AGENTS.md` is the vendor-neutral standard read by Codex, Cursor, Zed, and
other agent tooling. Symlinking it to `CLAUDE.md` gives those tools the same
instructions Claude Code already uses, with a single source of truth and zero
duplicated content.

## Notes

- Relative symlink (`AGENTS.md` -> `CLAUDE.md`), portable across clones.
- No content changes; `CLAUDE.md` remains canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)